### PR TITLE
Use the nicer svg badge for travis-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Boost.Metaparse
 
-[![Build Status](https://secure.travis-ci.org/boostorg/metaparse.png?branch=master "Build Status")](http://travis-ci.org/boostorg/metaparse)
+[![Build Status](https://secure.travis-ci.org/boostorg/metaparse.svg?branch=master "Build Status")](http://travis-ci.org/boostorg/metaparse)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/u7ysxkssmrgr7vau/branch/master?svg=true)](https://ci.appveyor.com/project/sabel83/metaparse-04v04/branch/master)
 
 Metaparse is parser generator library for template metaprograms. The purpose of


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/boostorg/metaparse.png?branch=master "Build Status")](http://travis-ci.org/boostorg/metaparse)
vs.
[![Build Status](https://secure.travis-ci.org/boostorg/metaparse.svg?branch=master "Build Status")](http://travis-ci.org/boostorg/metaparse)
