### PR TITLE
Fix redirect link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="refresh" content="0; URL=doc/html/index.html">
+<meta http-equiv="refresh" content="0; URL=../../doc/html/metaparse.html">
 </head>
 <body>
 Automatic redirection failed, please go to
-<a href="doc/html/index.html">doc/html/index.html</a>.&nbsp;<hr>
+<a href="../../doc/html/metaparse.html">../../doc/html/metaparse.html</a>.&nbsp;<hr>
 <p>© Copyright Beman Dawes, 2001</p>
 <p>Distributed under the Boost Software License, Version 1.0. (See accompanying 
 file <a href="../../LICENSE_1_0.txt">LICENSE_1_0.txt</a> or copy 


### PR DESCRIPTION
Documentation is currently built at:

http://www.boost.org/doc/libs/master/doc/html/metaparse.html