### PR TITLE
Missing qualifier for exit call.

### DIFF
--- a/include/boost/metaparse/v1/debug_parsing_error.hpp
+++ b/include/boost/metaparse/v1/debug_parsing_error.hpp
@@ -42,7 +42,7 @@ namespace boost
           cout << endl;
           runner::run();
           
-          exit(0);
+          std::exit(0);
         }
       
         typedef debug_parsing_error type;


### PR DESCRIPTION
libs/metaparse/example/parsing_error/main.cpp fails to compile with Oracle Solaris Studio12.5.
It would be great if this can get in for Boost 1.61.