### PR TITLE
Delete header-only library build.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -1,3 +1,0 @@
-build-project ../test ;
-build-project ../example ;
-


### PR DESCRIPTION
This file violates the Boost integration requirements. See "Building Sources" section of: http://www.boost.org/development/requirements.html#Integration