### PR TITLE
Remove usage of deprecated header boost/detail/iterator.hpp

### DIFF
--- a/example/regexp/main.cpp
+++ b/example/regexp/main.cpp
@@ -15,7 +15,6 @@
 #include <boost/metaparse/entire_input.hpp>
 #include <boost/metaparse/string.hpp>
 
-#include <boost/detail/iterator.hpp>
 #include <boost/xpressive/xpressive.hpp>
 
 #include <boost/mpl/bool.hpp>


### PR DESCRIPTION
This header generates deprecation warnings and will be removed in a future release.